### PR TITLE
work around for error logging in dev env

### DIFF
--- a/elm-pages.config.mjs
+++ b/elm-pages.config.mjs
@@ -2,7 +2,9 @@ import { defineConfig } from "vite";
 import adapter from "elm-pages/adapter/netlify.js";
 
 export default {
-  vite: defineConfig({}),
+  vite: defineConfig({
+    assetsInclude: ['/elm-pages.js']
+  }),
   adapter,
   headTagsTemplate(context) {
     return `


### PR DESCRIPTION
### Problem
Since upgrading elm pages and vite to latest version the dev server prints an annoying error message on some page loads:
```
[vite] Pre-transform error: Failed to load url /elm-pages.js (resolved id: /elm-pages.js). Does the file exist? (x2)
```

### Solution
Use workaround similar to the one described here https://github.com/vitejs/vite/issues/15374#issuecomment-1859842971