### PR TITLE
Use lamdera npm package instead of manual binary download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ functions/render/elm-pages-cli.js
 .idea/
 functions/
 codegen/Gen/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm install        # Install dependencies (also runs elm-tooling install)
+npm start          # Dev server on port 1234 (INCLUDE_DRAFTS=true)
+npm run build      # Build static site to dist/
+```
+
+For linting, elm-review config lives in `review/`:
+```bash
+npx elm-review    # Run from project root
+```
+
+## Architecture
+
+This is a personal blog/website built with **Elm Pages v3** (elm-pages 10.0.3). It generates a fully static site deployed to Netlify.
+
+### Routing
+
+Routes live in `app/Route/` and map directly to URL paths. Elm Pages uses file-based routing:
+- `app/Route/Index.elm` → `/`
+- `app/Route/Blog/Slug_.elm` → `/blog/:slug`
+- `app/Route/Tags/Slug_.elm` → `/tags/:slug`
+
+Routes use `RouteBuilder.preRender` with a `BackendTask` to enumerate all pages at build time. Data loading happens **at build time only**, not at runtime.
+
+### Content System
+
+Blog posts are markdown files in `content/blog/` with YAML frontmatter. `src/Content/Blogpost.elm` uses `BackendTask.Glob` to find all `.md` files and extract metadata (title, description, tags, authors, published date). The `Status` type distinguishes drafts from published posts — drafts are excluded unless `INCLUDE_DRAFTS=true`.
+
+Authors are defined in `content/authors/`.
+
+### Layout
+
+`src/Layout.elm` provides the global header/nav/footer wrapper. Blog post rendering uses `src/Layout/Markdown.elm` backed by `elm-markdown`. Styling is Tailwind CSS with the Nord color scheme defined in `tailwind.config.js` — Nord dark tones are `nord-0` through `nord-3`, light tones `nord-4` through `nord-6`, accent colors `nord-7` through `nord-15`.
+
+### Site Settings
+
+`src/Settings.elm` holds the canonical URL, site title, author name, and locale. Edit this file when changing site-wide identity.
+
+### Effect System
+
+`app/Effect.elm` wraps side effects. `app/Shared.elm` holds global layout state (e.g. mobile menu open/closed). `app/Site.elm` configures site-wide SEO defaults.
+
+### Code Generation
+
+`codegen/` contains elm-codegen scripts. `script/src/AddRoute.elm` is a helper to scaffold new route files.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   functions = "functions/"
   publish = "dist/"
-  command = "mkdir bin && export PATH=\"/opt/build/repo/bin:$PATH\" && echo $PATH && curl https://static.lamdera.com/bin/linux/lamdera -o bin/lamdera && chmod a+x bin/lamdera && export ELM_HOME=\"$NETLIFY_BUILD_BASE/cache/elm\" && npm install && npm run build"
+  command = "export ELM_HOME=\"$NETLIFY_BUILD_BASE/cache/elm\" && npm install && npm run build"
 
 [dev]
   command = "npm start"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "elm-pages-app",
       "hasInstallScript": true,
       "dependencies": {
-        "@netlify/functions": "^1.4.0"
+        "@netlify/functions": "^1.4.0",
+        "lamdera": "^0.19.1-1.4.0"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.10",
@@ -555,6 +556,71 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lamdera/compiler-darwin-arm64": {
+      "version": "0.19.1-1.4.0",
+      "resolved": "https://registry.npmjs.org/@lamdera/compiler-darwin-arm64/-/compiler-darwin-arm64-0.19.1-1.4.0.tgz",
+      "integrity": "sha512-zLqkIm5wMtuWyFnWlpgXgN0/nfEYRqvcSXEg9R/SlDL5yb8cle3sJCkR5S7zcqBc3zknjb24gWgpWzd0BSkkZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lamdera/compiler-darwin-x64": {
+      "version": "0.19.1-1.4.0",
+      "resolved": "https://registry.npmjs.org/@lamdera/compiler-darwin-x64/-/compiler-darwin-x64-0.19.1-1.4.0.tgz",
+      "integrity": "sha512-hMG/uKWeL7hp8EeodmSo9Tg9X1P8Xzshai8E/RNtn2LpLCZ6yeRsIjzxpKqV8cEkVCI9yamnT6QTMywexPceYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lamdera/compiler-linux-arm64": {
+      "version": "0.19.1-1.4.0",
+      "resolved": "https://registry.npmjs.org/@lamdera/compiler-linux-arm64/-/compiler-linux-arm64-0.19.1-1.4.0.tgz",
+      "integrity": "sha512-ZLO4Z1jCW4O/9Zoa9LXME+DklUGaOOv6JW7ulWYxSdgvu68Lgkfx47HZidM96R9tehX0Q1wZ+fBmZQkU/a7biQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lamdera/compiler-linux-x64": {
+      "version": "0.19.1-1.4.0",
+      "resolved": "https://registry.npmjs.org/@lamdera/compiler-linux-x64/-/compiler-linux-x64-0.19.1-1.4.0.tgz",
+      "integrity": "sha512-r7tx1p/+dSw9SLUL3K7dSj1RBb/1Y5kmE27i9jarOlTeEUr1pycUqt3FSomD0EbTp8Rcp7jRCaNWvb5IWFathg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lamdera/compiler-win32-x64": {
+      "version": "0.19.1-1.4.0",
+      "resolved": "https://registry.npmjs.org/@lamdera/compiler-win32-x64/-/compiler-win32-x64-0.19.1-1.4.0.tgz",
+      "integrity": "sha512-hLpi1eikdY9BA87ipqhTP8gY0l75yih7kjckD30CrIOMMqEWbgaK/0yr2JxTQJiSt6D2A1VZiUbqjHMiSTbPZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@netlify/functions": {
       "version": "1.6.0",
@@ -3523,6 +3589,23 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lamdera": {
+      "version": "0.19.1-1.4.0",
+      "resolved": "https://registry.npmjs.org/lamdera/-/lamdera-0.19.1-1.4.0.tgz",
+      "integrity": "sha512-F5HqnNJPXulkr6/0XCNhaRhESjewG2iTHc+EKg8mJLj76E2PscuUOVhnBEjPqeFrEZF6RT53qSeWtSYG61fhpQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "lamdera": "bin/lamdera"
+      },
+      "optionalDependencies": {
+        "@lamdera/compiler-darwin-arm64": "0.19.1-1.4.0",
+        "@lamdera/compiler-darwin-x64": "0.19.1-1.4.0",
+        "@lamdera/compiler-linux-arm64": "0.19.1-1.4.0",
+        "@lamdera/compiler-linux-x64": "0.19.1-1.4.0",
+        "@lamdera/compiler-win32-x64": "0.19.1-1.4.0"
       }
     },
     "node_modules/latest-version": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vite": "^5.0.11"
   },
   "dependencies": {
-    "@netlify/functions": "^1.4.0"
+    "@netlify/functions": "^1.4.0",
+    "lamdera": "^0.19.1-1.4.0"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `lamdera` as an npm dependency (`^0.19.1-1.4.0`)
- Simplifies the Netlify build command — removes the manual `curl`/`chmod` Lamdera binary download
- `package-lock.json` updated with platform-specific optional compiler binaries

Mirrors: https://github.com/kraklin/elm-pages-blog-starter/commit/5e63f142672f05f85e7a8af9b7c42b31f1a9e6d6

## Test plan

- [x] Dev server starts with `npm start`
- [ ] Netlify build succeeds with simplified command

Generated with [Claude Code](https://claude.com/claude-code)