### PR TITLE
Upgrade Elm dependencies

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "direct": {
             "dillonkearns/elm-bcp47-language-tag": "2.0.0",
-            "dillonkearns/elm-form": "3.0.1",
+            "dillonkearns/elm-form": "3.1.0",
             "dillonkearns/elm-markdown": "7.0.1",
             "dillonkearns/elm-pages": "11.0.0",
             "elm/browser": "1.0.2",
@@ -41,12 +41,11 @@
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/virtual-dom": "1.0.5",
-            "elm-community/basics-extra": "4.1.0",
-            "elm-community/maybe-extra": "5.3.0",
+            "elmcraft/core-extra": "2.3.0",
             "fredcy/elm-parseint": "2.0.1",
             "jluckyiv/elm-utc-date-strings": "1.0.0",
-            "mdgriffith/elm-codegen": "6.0.1",
-            "miniBill/elm-codec": "2.3.0",
+            "mdgriffith/elm-codegen": "6.0.3",
+            "miniBill/elm-codec": "2.3.1",
             "miniBill/elm-unicode": "1.1.1",
             "noahzgordon/elm-color-extra": "1.0.2",
             "robinheghan/fnv1a": "1.0.0",
@@ -56,8 +55,8 @@
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
             "stil4m/elm-syntax": "7.3.9",
             "stil4m/structured-writer": "1.0.3",
-            "the-sett/elm-pretty-printer": "3.3.0",
-            "the-sett/elm-syntax-dsl": "6.0.3",
+            "the-sett/elm-pretty-printer": "3.3.1",
+            "the-sett/elm-syntax-dsl": "6.0.5",
             "wolfadex/elm-ansi": "3.0.1"
         }
     },


### PR DESCRIPTION
## Summary

- `dillonkearns/elm-form` 3.0.1 → 3.1.0
- `elm-community/basics-extra` + `elm-community/maybe-extra` replaced by `elmcraft/core-extra` 2.3.0
- Minor bumps: `mdgriffith/elm-codegen`, `miniBill/elm-codec`, `the-sett/elm-pretty-printer`, `the-sett/elm-syntax-dsl`

Build passes cleanly after upgrade.

## Test plan

- [x] `npm run build` succeeds with all pages rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)