### PR TITLE
Upgrade review deps and remove unused logo function

### DIFF
--- a/review/elm.json
+++ b/review/elm.json
@@ -7,27 +7,26 @@
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
-            "elm/json": "1.1.3",
+            "elm/json": "1.1.4",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.13.1",
-            "jfmengels/elm-review-code-style": "1.1.4",
-            "jfmengels/elm-review-common": "1.3.3",
+            "jfmengels/elm-review": "2.16.6",
+            "jfmengels/elm-review-code-style": "1.2.0",
+            "jfmengels/elm-review-common": "1.3.5",
             "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-documentation": "2.0.4",
-            "jfmengels/elm-review-simplify": "2.1.1",
-            "jfmengels/elm-review-unused": "1.2.0",
-            "stil4m/elm-syntax": "7.3.2"
+            "jfmengels/elm-review-simplify": "2.1.15",
+            "jfmengels/elm-review-unused": "1.2.6",
+            "stil4m/elm-syntax": "7.3.9"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
+            "elm/html": "1.0.1",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.3",
-            "elm-explorations/test": "2.1.1",
-            "miniBill/elm-unicode": "1.0.3",
+            "elm/virtual-dom": "1.0.5",
+            "elm-explorations/test": "2.2.1",
             "pzp1997/assoc-list": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"

--- a/src/Layout.elm
+++ b/src/Layout.elm
@@ -45,29 +45,6 @@ menu =
     ]
 
 
-logo : Html msg
-logo =
-    Html.div
-        [ Attrs.class "mr-1 text-primary-600 dark:text-primary-500"
-        ]
-        [ Svg.svg
-            [ SvgAttrs.width "80"
-            , SvgAttrs.height "80"
-            , SvgAttrs.viewBox "0 0 700 351"
-            ]
-            [ Svg.g
-                [ SvgAttrs.fill "currentColor"
-                , SvgAttrs.fillRule "evenodd"
-                ]
-                [ Svg.path
-                    [ SvgAttrs.d "M529.5 169 700 0H359zM349.7 349l79.7-79H270zM266.2 86.5l79 79.7V6.8zM352 180h168l-82 82H270zM175.77 176.5l84.85-84.85 84.85 84.85-84.85 84.85zM353.03 173.3l166.87-1.4L354.44 6.42zM170.5 182 341 351H0z"
-                    ]
-                    []
-                ]
-            ]
-        ]
-
-
 viewMainMenuItem : { label : String, route : Route } -> Html msg
 viewMainMenuItem { label, route } =
     Route.link


### PR DESCRIPTION
## Summary

- Upgraded `review/elm.json` dependencies (notably `jfmengels/elm-review` 2.13.1 → 2.16.6 and several review plugins)
- Removed unused `logo` function in `src/Layout.elm` (flagged by the upgraded elm-review-unused rule)

## Test plan

- [x] `npx elm-review` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)