### PR TITLE
Sync upstream template PRs #9, #12, #13, #14, #17

### DIFF
--- a/app/Api.elm
+++ b/app/Api.elm
@@ -2,10 +2,13 @@ module Api exposing (manifest, routes)
 
 import ApiRoute exposing (ApiRoute)
 import BackendTask exposing (BackendTask)
+import Content.Blogpost
 import FatalError exposing (FatalError)
 import Html exposing (Html)
+import Pages
 import Pages.Manifest as Manifest
 import Route exposing (Route)
+import Rss
 import Settings
 
 
@@ -14,7 +17,51 @@ routes :
     -> (Maybe { indent : Int, newLines : Bool } -> Html Never -> String)
     -> List (ApiRoute ApiRoute.Response)
 routes getStaticRoutes htmlToString =
-    []
+    [ manifestRoute
+    , rssRoute
+    ]
+
+
+rssRoute : ApiRoute ApiRoute.Response
+rssRoute =
+    ApiRoute.succeed
+        (Content.Blogpost.allBlogposts
+            |> BackendTask.map
+                (\blogposts ->
+                    Rss.generate
+                        { title = Settings.title
+                        , description = Settings.subtitle
+                        , url = Settings.canonicalUrl ++ "/blog"
+                        , lastBuildTime = Pages.builtAt
+                        , generator = Just "elm-pages"
+                        , items = List.map blogpostToRssItem blogposts
+                        , siteUrl = Settings.canonicalUrl
+                        }
+                )
+        )
+        |> ApiRoute.literal "blog"
+        |> ApiRoute.slash
+        |> ApiRoute.literal "feed.xml"
+        |> ApiRoute.single
+
+
+blogpostToRssItem : Content.Blogpost.Blogpost -> Rss.Item
+blogpostToRssItem { metadata } =
+    { title = metadata.title
+    , description = metadata.description |> Maybe.withDefault ""
+    , url = "/blog/" ++ metadata.slug
+    , categories = metadata.tags
+    , author = metadata.authors |> List.map .name |> String.join ", "
+    , pubDate = Rss.Date (Content.Blogpost.getPublishedDate metadata)
+    , content = Nothing
+    , contentEncoded = Nothing
+    , enclosure = Nothing
+    }
+
+
+manifestRoute : ApiRoute ApiRoute.Response
+manifestRoute =
+    Manifest.generator Settings.canonicalUrl (BackendTask.succeed manifest)
 
 
 manifest : Manifest.Config

--- a/app/Site.elm
+++ b/app/Site.elm
@@ -18,5 +18,6 @@ head : BackendTask FatalError (List Head.Tag)
 head =
     [ Head.metaName "viewport" (Head.raw "width=device-width,initial-scale=1")
     , Head.sitemapLink "/sitemap.xml"
+    , Head.rssLink "/blog/feed.xml"
     ]
         |> BackendTask.succeed

--- a/elm-pages.config.mjs
+++ b/elm-pages.config.mjs
@@ -15,9 +15,8 @@ export default {
 <meta name="generator" content="elm-pages v${context.cliVersion}" />
 <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
 <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0f172a" />
+<link rel="manifest" href="/manifest.json">
 `;
-//  <link rel="manifest" href="manifest.json">
-
   },
   preloadTagForFile(file) {
     // add preload directives for JS assets and font assets, etc., skip for CSS files

--- a/elm.json
+++ b/elm.json
@@ -28,6 +28,7 @@
             "justinmimbs/date": "4.1.0",
             "kuon/elm-string-normalize": "1.0.6",
             "pablohirafuji/elm-syntax-highlight": "3.7.1",
+            "dillonkearns/elm-rss": "2.0.5",
             "phosphor-icons/phosphor-elm": "2.1.0"
         },
         "indirect": {
@@ -57,6 +58,11 @@
             "stil4m/structured-writer": "1.0.3",
             "the-sett/elm-pretty-printer": "3.3.1",
             "the-sett/elm-syntax-dsl": "6.0.5",
+            "dillonkearns/elm-xml-encode": "1.0.1",
+            "dmy/elm-imf-date-time": "1.0.2",
+            "justinmimbs/time-extra": "1.2.0",
+            "lazamar/dict-parser": "1.0.2",
+            "ryan-haskell/date-format": "1.0.0",
             "wolfadex/elm-ansi": "3.0.1"
         }
     },

--- a/src/Content/Blogpost.elm
+++ b/src/Content/Blogpost.elm
@@ -6,6 +6,7 @@ module Content.Blogpost exposing
     , allBlogposts
     , allTags
     , blogpostFromSlug
+    , getPublishedDate
     )
 
 import Array
@@ -20,12 +21,14 @@ import FatalError exposing (FatalError)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Extra as Decode
 import List.Extra
+import Markdown.Block exposing (Block)
+import Markdown.Parser
 import String.Normalize
 
 
 type alias Blogpost =
     { metadata : Metadata
-    , body : String
+    , body : List Block
     , previousPost : Maybe Metadata
     , nextPost : Maybe Metadata
     }
@@ -156,14 +159,6 @@ allBlogposts =
                     )
                 |> BackendTask.map Array.toList
 
-        updateReadingTime blogposts =
-            let
-                updatedMetadata blogpost metadata =
-                    { metadata | readingTimeInMin = String.split " " blogpost |> List.length |> (\words -> words // 200) }
-            in
-            blogposts
-                |> BackendTask.map (List.map (\blogpost -> { blogpost | metadata = updatedMetadata blogpost.body blogpost.metadata }))
-
         addDraftTag metadata =
             case metadata.status of
                 Draft ->
@@ -179,9 +174,29 @@ allBlogposts =
                     file.filePath
                         |> File.bodyWithFrontmatter
                             (\markdownString ->
-                                Decode.map2 (\metadata body -> Blogpost metadata body Nothing Nothing)
+                                let
+                                    parsedBody : Result String (List Block)
+                                    parsedBody =
+                                        markdownString
+                                            |> Markdown.Parser.parse
+                                            |> Result.mapError (\_ -> "Failed to parse markdown")
+                                in
+                                Decode.map2
+                                    (\metadata body ->
+                                        Blogpost
+                                            { metadata | readingTimeInMin = calculateReadingTime markdownString }
+                                            body
+                                            Nothing
+                                            Nothing
+                                    )
                                     (metadataDecoder authorsDict file.slug)
-                                    (Decode.succeed markdownString)
+                                    (case parsedBody of
+                                        Ok blocks ->
+                                            Decode.succeed blocks
+
+                                        Err err ->
+                                            Decode.fail err
+                                    )
                             )
                         |> BackendTask.map (\blogpost -> { blogpost | metadata = addDraftTag blogpost.metadata })
                         |> BackendTask.allowFatal
@@ -207,7 +222,11 @@ allBlogposts =
         |> BackendTask.map
             (List.sortBy (.metadata >> getPublishedDate >> Date.toRataDie) >> List.reverse)
         |> addPreviousNextPosts
-        |> updateReadingTime
+
+
+calculateReadingTime : String -> Int
+calculateReadingTime markdownString =
+    String.split " " markdownString |> List.length |> (\words -> words // 200)
 
 
 allBlogpostsDict : BackendTask FatalError (Dict String Blogpost)

--- a/src/Layout/About.elm
+++ b/src/Layout/About.elm
@@ -152,6 +152,6 @@ view author =
                 [ Attrs.class "prose max-w-none pb-8 pt-8 dark:prose-invert xl:col-span-2"
                 ]
               <|
-                Markdown.toHtml author.body
+                Markdown.toHtmlBlocks author.body
             ]
         ]

--- a/src/Layout/Blogpost.elm
+++ b/src/Layout/Blogpost.elm
@@ -12,6 +12,7 @@ import Html.Extra
 import Layout.Markdown as Markdown
 import Layout.Tags
 import Route
+import SyntaxHighlight
 
 
 
@@ -104,7 +105,8 @@ viewBlogpost { metadata, body, previousPost, nextPost } =
             Html.div
                 [ Attrs.class "max-w-[65ch] m-auto space-y-1 xl:text-xl dark:border-gray-700"
                 ]
-                [ Html.div
+                [ SyntaxHighlight.useTheme SyntaxHighlight.oneDark
+                , Html.div
                     []
                     [ Html.h1 [ Attrs.class "mt-8 pb-4 font-bold text-3xl md:text-5xl text-gray-900 dark:text-nord-6" ]
                         [ Html.text metadata.title
@@ -155,7 +157,7 @@ viewBlogpost { metadata, body, previousPost, nextPost } =
             metadata.description
         , Html.article
             [ Attrs.class "mx-auto prose lg:prose-xl dark:prose-invert" ]
-            (Markdown.blogpostToHtml body)
+            (Markdown.blocksToHtml body)
         , Html.div
             [ Attrs.class "mt-8 border-t grid grid-cols-1 text-sm font-medium sm:grid-cols-2 sm:text-base" ]
             [ previous, next ]
@@ -184,7 +186,7 @@ viewPublishedDate status =
                     [ Html.time
                         [ Attrs.datetime <| Date.toIsoString date
                         ]
-                        [ Html.text <| Date.format "d MMM YYYY" date ]
+                        [ Html.text <| Date.format "d. MMM yyyy" date ]
                     ]
                 ]
 

--- a/src/Layout/Markdown.elm
+++ b/src/Layout/Markdown.elm
@@ -1,9 +1,8 @@
-module Layout.Markdown exposing (blogpostToHtml, toHtml)
+module Layout.Markdown exposing (blocksToHtml, toHtmlBlocks)
 
 import Html exposing (Html)
 import Html.Attributes as Attrs
 import Markdown.Block as Block
-import Markdown.Parser
 import Markdown.Renderer exposing (defaultHtmlRenderer)
 import Parser exposing (DeadEnd)
 import Phosphor
@@ -53,9 +52,8 @@ syntaxHighlight codeBlock =
             else
                 codeBlock.body
     in
-    Html.div [ Attrs.class "no-prose" ]
-        [ SyntaxHighlight.useTheme SyntaxHighlight.oneDark
-        , language codeBlock.language sanitiseCodeBlock
+    Html.div [ Attrs.class "no-prose mt-4" ]
+        [ language codeBlock.language sanitiseCodeBlock
             |> Result.map (SyntaxHighlight.toBlockHtml (Just 1))
             |> Result.withDefault
                 (Html.pre [] [ Html.code [] [ Html.text sanitiseCodeBlock ] ])
@@ -109,35 +107,22 @@ blogpostRenderer =
                             |> Phosphor.toHtml [ SvgAttrs.class "text-primary-300 inline-block text-xl ml-2" ]
                         ]
                     ]
+        , codeSpan =
+            \context ->
+                Html.code [ Attrs.class "not-prose" ] [ Html.text context ]
         , codeBlock =
             \block ->
                 syntaxHighlight block
     }
 
 
-blogpostToHtml : String -> List (Html msg)
-blogpostToHtml markdownString =
-    markdownString
-        |> Markdown.Parser.parse
-        |> Result.mapError (\_ -> "Markdown error.")
-        |> Result.andThen
-            (\blocks ->
-                Markdown.Renderer.render
-                    blogpostRenderer
-                    blocks
-            )
-        |> Result.withDefault [ Html.text "failed to read markdown" ]
+blocksToHtml : List Block.Block -> List (Html msg)
+blocksToHtml blocks =
+    Markdown.Renderer.render blogpostRenderer blocks
+        |> Result.withDefault [ Html.text "failed to render markdown" ]
 
 
-toHtml : String -> List (Html msg)
-toHtml markdownString =
-    markdownString
-        |> Markdown.Parser.parse
-        |> Result.mapError (\_ -> "Markdown error.")
-        |> Result.andThen
-            (\blocks ->
-                Markdown.Renderer.render
-                    renderer
-                    blocks
-            )
-        |> Result.withDefault [ Html.text "failed to read markdown" ]
+toHtmlBlocks : List Block.Block -> List (Html msg)
+toHtmlBlocks blocks =
+    Markdown.Renderer.render renderer blocks
+        |> Result.withDefault [ Html.text "failed to render markdown" ]

--- a/style.css
+++ b/style.css
@@ -55,6 +55,15 @@ body {
   @apply antialiased text-slate-500 dark:text-nord-4 bg-white dark:bg-nord-0
 }
 
+/* Make <pre> elements not contribute to the width calculation of parents.
+ * Instead, let them be as wide as the parent.
+ * This allows a horizontal scrollbar to appear instead of making the whole
+ * article wider, overflowing its parent, and going offscreen on phones.
+ */
+pre {
+  contain: inline-size;
+}
+
 /* Elm Syntax Highlight CSS */
 pre.elmsh {
   padding: 10px;
@@ -65,6 +74,12 @@ pre.elmsh {
 
 code.elmsh {
   padding: 0;
+}
+
+code.not-prose {
+  border-radius: .3em;
+  background: color-mix(in srgb, var(--color-nord-13) 20%, transparent);
+  padding: .15em .2em .05em;
 }
 
 .elmsh-line:before {


### PR DESCRIPTION
## Summary

Applies 5 merged PRs from the upstream template [kraklin/elm-pages-blog-starter](https://github.com/kraklin/elm-pages-blog-starter):

- **#9 — Build-time markdown parsing:** `Blogpost.body` and `About.body` now hold pre-parsed `List Block` instead of raw strings. Markdown/syntax-highlight rendering is dead-code-eliminated from the client JS bundle.
- **#12 — Inline code span styling:** Custom `codeSpan` renderer wraps inline code in `<code class="not-prose">` with a Nord-yellow tinted background (`nord-13` at 20% opacity).
- **#13 — Blogpost layout backports:** `SyntaxHighlight.useTheme` injected once per page instead of per block; `pre { contain: inline-size }` prevents wide code blocks from breaking mobile layout.
- **#14 — Basic RSS feed:** `/blog/feed.xml` generated via `dillonkearns/elm-rss`, auto-discovered via `<link>` in the site `<head>`.
- **#17 — Webmanifest:** Restores `/manifest.json` generation and `<link rel="manifest">` in `elm-pages.config.mjs`.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `/blog/feed.xml` present in `dist/`
- [ ] `/manifest.json` present in `dist/`
- [ ] Blog posts render with styled inline code
- [ ] Code blocks have correct syntax highlighting and no horizontal overflow on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)